### PR TITLE
Jenkinsfile: Send emails also to last committer & SonarQube analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@6cd41e0')
+@Library('github.com/cloudogu/ces-build-lib@b5f6848')
 import com.cloudogu.ces.cesbuildlib.*
 
 node {
@@ -48,5 +48,21 @@ node {
   // Find maven warnings and visualize in job
   warnings consoleParsers: [[parserName: 'Maven']]
 
-  mailIfStatusChanged(env.EMAIL_RECIPIENTS_COMMAND_BUS)
+  mailIfStatusChanged(getCommitAuthorOrDefaultEmailRecipients(env.EMAIL_RECIPIENTS_COMMAND_BUS))
+}
+
+String getCommitAuthorOrDefaultEmailRecipients(String defaultRecipients) {
+  def isStableBranch = env.BRANCH_NAME in ['master', 'develop']
+  String commitAuthorEmail =  new Git(this).commitAuthorEmail
+
+  if (commitAuthorEmail == null && commitAuthorEmail.isEmpty())
+    return defaultRecipients
+  if (isStableBranch) {
+    if (!defaultRecipients.contains(commitAuthorEmail)) {
+      defaultRecipients += ";$commitAuthorEmail"
+    }
+    return defaultRecipients
+  } else {
+    return commitAuthorEmail
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,15 @@ node {
     stage('Integration Test') {
       mvn "verify -DskipUnitTests"
     }
+
+    stage('Statical Code Analysis') {
+      withSonarQubeEnv('sonarcloud.io') {
+        mvn "$SONAR_MAVEN_GOAL -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN $SONAR_EXTRA_PROPS " +
+          //exclude generated code in target folder
+          "-Dsonar.exclusions=target/**"
+        // TODO check quality gate
+      }
+    }
   }
 
   // Archive Unit and integration test results, if any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,16 +48,17 @@ node {
         mvn "$SONAR_MAVEN_GOAL -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN $SONAR_EXTRA_PROPS " +
           //exclude generated code in target folder
           "-Dsonar.exclusions=target/**"
+      }
 
-        // Pull Requests are analyzed locally, so no calling of the QGate webhook
-        if (!isPullRequest()) {
-          timeout(time: 1, unit: 'HOURS') {
-            // This will only work if a webhook to <JenkinsInstance>/sonarqube-webhook/ is set up in SQ project
-            def qgate = waitForQualityGate()
-            if (qgate.status != 'OK') {
-              echo "Quality Gate failure: ${qgate.status} --> Build UNSTABLE"
-              currentBuild.result = 'UNSTABLE'
-            }
+      // Pull Requests are analyzed locally, so no calling of the QGate webhook
+      if (!isPullRequest()) {
+        timeout(time: 1, unit: 'HOURS') {
+          // This will only work if a webhook to <JenkinsInstance>/sonarqube-webhook/ is set up in SQ project
+          // See https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Jenkins
+          def qgate = waitForQualityGate()
+          if (qgate.status != 'OK') {
+            echo "Quality Gate failure: ${qgate.status} --> Build UNSTABLE"
+            currentBuild.result = 'UNSTABLE'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,11 +92,9 @@ void initMaven(Maven mvn, String sonarGitHubCredentials, String gitHubrepoName) 
       echo "Building branch ${env.BRANCH_NAME}"
 
       // Run SQ analysis in specific project for feature, hotfix, etc.
-      // Note that this is deprecated from SQ 6.6. Branch feature only in commercial editions. Workaround by adding ":${env.BRANCH_NAME} to all keys?
-      // https://docs.sonarqube.org/display/SONAR/Analysis+Parameters
-      // https://www.sonarsource.com/resources/product-news/news.html#6.7-lts-released
-      // https://www.sonarsource.com/plans-and-pricing/developer/
-      mvn.additionalArgs = "-Dsonar.branch=" + env.BRANCH_NAME
+      // See https://docs.sonarqube.org/display/PLUG/Branch+Plugin
+      // Note that -Dsonar.branch is deprecated from SQ 6.6: https://docs.sonarqube.org/display/SONAR/Analysis+Parameters
+      mvn.additionalArgs = "-Dsonar.branch.name=$env.BRANCH_NAME -Dsonar.branch.target=master"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # command-bus
-[![Build Status](https://opensource.triology.de/jenkins/buildStatus/icon?job=triologygmbh-github/command-bus/master)](https://opensource.triology.de/jenkins/job/triologygmbh-github/job/command-bus/job/master/)
+[![Build Status](https://opensource.triology.de/jenkins/buildStatus/icon?job=triologygmbh-github/command-bus/master)](https://opensource.triology.de/jenkins/blue/organizations/jenkins/triologygmbh-github%2Fcommand-bus/branches/)
+[![Quality Gates](https://sonarcloud.io/api/badges/gate?key=de.triology.cb%3Acommand-bus)](https://sonarcloud.io/dashboard?id=de.triology.cb%3Acommand-bus)
+[![Coverage](https://sonarcloud.io/api/badges/measure?key=de.triology.cb%3Acommand-bus&metric=coverage)](https://sonarcloud.io/dashboard?id=de.triology.cb%3Acommand-bus)
+[![Technical Debt](https://sonarcloud.io/api/badges/measure?key=de.triology.cb%3Acommand-bus&metric=sqale_debt_ratio)](https://sonarcloud.io/dashboard?id=de.triology.cb%3Acommand-bus)
 [![JitPack](https://jitpack.io/v/triologygmbh/command-bus.svg)](https://jitpack.io/#triologygmbh/command-bus)
 
 CDI enabled Java Command-Bus

--- a/pom.xml
+++ b/pom.xml
@@ -284,4 +284,42 @@
     <skipUnitTests>${skipTests}</skipUnitTests>
   </properties>
 
+  <profiles>
+    <profile>
+      <!-- profile is active on every jenkins build -->
+      <id>jenkins</id>
+
+      <activation>
+        <property>
+          <name>env.BUILD_URL</name>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <!-- prepare jacoco agent for code coverage in sonar -->
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>agent-for-it</id>
+                <goals>
+                  <goal>prepare-agent-integration</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.9</version>
             <executions>
               <execution>
                 <phase>initialize</phase>


### PR DESCRIPTION
Right now when someone creates a branch or a PR Jenkins sends build failure emails only to the recipients defined in Jenkins. This might not include the committer.

This PR changes this behaviour.

In addition we now have SonarQube analysis for our branches and PRs.
SQ issues in PRs should be commented right into the GitHub code by @triomarvin.